### PR TITLE
fix: release workflow test failures and arm64 push permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           workspaces: genesis-core
 
       - name: Build Rust static library
-        run: cd genesis-core && cargo build --release
+        run: cd genesis-core && cargo build --release --features mock
 
       - name: Generate C header
         run: |
@@ -106,6 +106,9 @@ jobs:
   docker-arm64:
     name: Docker (arm64)
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:


### PR DESCRIPTION
## Summary
- Add `--features mock` to the Rust static library build in the release workflow's GoReleaser job, matching what `ci.yml` already does. Without this feature flag, the Rust `create_provider("mock")` call returns `KmsNotConfigured`, causing 9 Go test failures in `cmd/genesis` and `internal/bridge`.
- Add explicit `permissions: { contents: read, packages: write }` to the `docker-arm64` job. The `ubuntu-24.04-arm` runner does not properly inherit workflow-level GHCR token permissions, resulting in `permission_denied: write_package` when pushing the arm64 image.

## Test plan
- [ ] Re-run the release workflow (tag v0.4.1 or re-trigger v0.4.0) and verify all GoReleaser tests pass
- [ ] Verify arm64 Docker image pushes to GHCR successfully
- [ ] Verify multi-arch manifest creation completes